### PR TITLE
Fix code scanning alert no. 39: Prototype-polluting assignment

### DIFF
--- a/src/controllers/api/gildWeaponController.ts
+++ b/src/controllers/api/gildWeaponController.ts
@@ -29,8 +29,9 @@ export const gildWeaponController: RequestHandler = async (req, res) => {
     const accountId = await getAccountIdForRequest(req);
     const data: IGildWeaponRequest = getJSONfromString(String(req.body));
     data.ItemId = String(req.query.ItemId);
-    if (!modularWeaponCategory.includes(req.query.Category as WeaponTypeInternal | "Hoverboards")) {
-        throw new Error(`Unknown modular weapon Category: ${req.query.Category}`);
+    if (!modularWeaponCategory.includes(req.query.Category as WeaponTypeInternal | "Hoverboards") ||
+        req.query.Category === '__proto__' || req.query.Category === 'constructor' || req.query.Category === 'prototype') {
+        throw new Error(`Unknown or invalid modular weapon Category: ${req.query.Category}`);
     }
     data.Category = req.query.Category as WeaponTypeInternal | "Hoverboards";
 

--- a/src/controllers/api/gildWeaponController.ts
+++ b/src/controllers/api/gildWeaponController.ts
@@ -29,7 +29,7 @@ export const gildWeaponController: RequestHandler = async (req, res) => {
     const accountId = await getAccountIdForRequest(req);
     const data: IGildWeaponRequest = getJSONfromString(String(req.body));
     data.ItemId = String(req.query.ItemId);
-    if (!modularWeaponCategory.includes(req.query.Category as WeaponTypeInternal | "Hoverboards") ||
+        if (!modularWeaponCategory.includes(req.query.Category as WeaponTypeInternal | "Hoverboards") ||
         req.query.Category === '__proto__' || req.query.Category === 'constructor' || req.query.Category === 'prototype') {
         throw new Error(`Unknown or invalid modular weapon Category: ${req.query.Category}`);
     }


### PR DESCRIPTION
Fixes [https://github.com/lonewolf0708/SpaceNinjaServer/security/code-scanning/39](https://github.com/lonewolf0708/SpaceNinjaServer/security/code-scanning/39)

To fix the problem, we need to ensure that the `data.Category` value cannot be set to `__proto__`, `constructor`, or `prototype`. This can be achieved by adding an explicit check to reject these values before proceeding with the assignment.

- Add a check to ensure `req.query.Category` is not `__proto__`, `constructor`, or `prototype`.
- If the value is one of these special property names, throw an error or handle it appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for the `Category` parameter to prevent the use of harmful prototype properties.
	- Updated error messages for invalid or unknown categories.

These improvements ensure a more secure and reliable user experience when interacting with weapon gilding features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->